### PR TITLE
TIS-862/add optional blob metadata support

### DIFF
--- a/gcp-storage/src/main/java/org/rutebanken/helper/gcp/repository/GcsBlobStoreRepository.java
+++ b/gcp-storage/src/main/java/org/rutebanken/helper/gcp/repository/GcsBlobStoreRepository.java
@@ -21,10 +21,12 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import org.rutebanken.helper.gcp.BlobStoreHelper;
+import org.rutebanken.helper.storage.model.BlobDescriptor;
 import org.rutebanken.helper.storage.repository.BlobStoreRepository;
 
 import java.io.InputStream;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Blob store repository targeting Google Cloud Storage.
@@ -55,6 +57,19 @@ public class GcsBlobStoreRepository implements BlobStoreRepository {
     @Override
     public InputStream getBlob(String name) {
         return BlobStoreHelper.getBlob(storage, containerName, name);
+    }
+
+    @Override
+    public long uploadBlob(BlobDescriptor blobDescriptor) {
+        Blob blob = BlobStoreHelper.createOrReplace(
+                storage,
+                containerName,
+                blobDescriptor.name(),
+                blobDescriptor.inputStream(),
+                false,
+                blobDescriptor.contentType().orElse(BlobStoreHelper.DEFAULT_CONTENT_TYPE),
+                blobDescriptor.metadata().orElse(Map.of()));
+        return blob.getGeneration();
     }
 
     @Override

--- a/storage/src/main/java/org/rutebanken/helper/storage/model/BlobDescriptor.java
+++ b/storage/src/main/java/org/rutebanken/helper/storage/model/BlobDescriptor.java
@@ -1,0 +1,27 @@
+package org.rutebanken.helper.storage.model;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Descriptor type for representing a blob to store with all properties which may be attached to it.
+ * @param name
+ * @param inputStream
+ * @param contentType
+ * @param metadata
+ */
+public record BlobDescriptor(String name,
+                             InputStream inputStream,
+                             Optional<String> contentType,
+                             Optional<Map<String, String>> metadata) {
+
+    /**
+     * Convenience constructor for building <code>BlobDescriptor</code> with just the required parameters.
+     * @param name
+     * @param inputStream
+     */
+    public BlobDescriptor(String name, InputStream inputStream) {
+        this(name, inputStream, Optional.empty(), Optional.empty());
+    }
+}

--- a/storage/src/main/java/org/rutebanken/helper/storage/repository/BlobStoreRepository.java
+++ b/storage/src/main/java/org/rutebanken/helper/storage/repository/BlobStoreRepository.java
@@ -17,6 +17,7 @@
 package org.rutebanken.helper.storage.repository;
 
 import org.rutebanken.helper.storage.BlobAlreadyExistsException;
+import org.rutebanken.helper.storage.model.BlobDescriptor;
 
 import java.io.InputStream;
 
@@ -37,6 +38,21 @@ public interface BlobStoreRepository {
      * @return an InputStream on the file content.
      */
     InputStream getBlob(String objectName);
+
+    /**
+     * Upload a blob and return its generation number.
+     *
+     * @param blobDescriptor Container type describing the blob to upload.
+     * @return the blob generation
+     * @see #uploadBlob(String, InputStream)
+     */
+    default long uploadBlob(BlobDescriptor blobDescriptor) {
+        if (blobDescriptor.contentType().isPresent()) {
+            return uploadBlob(blobDescriptor.name(), blobDescriptor.inputStream(), blobDescriptor.contentType().get());
+        } else {
+            return uploadBlob(blobDescriptor.name(), blobDescriptor.inputStream());
+        }
+    }
 
     /**
      * Upload a blob and returns its generation number.


### PR DESCRIPTION
Adds `BlobDescriptor` for encapsulating blob upload related options and some basic default functionality for supporting its use.

Implementations are expected to reimplement the default implementation if better handling is desired, as example I went ahead and modified `GcsBlobStoreRepository` to demonstrate this.

Fixes #301 