### PR TITLE
Add exist method on BlobStoreRepository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <hazelcast-kubernetes.version>2.2.3</hazelcast-kubernetes.version>
         <httpclient5.version>5.4.1</httpclient5.version>
         <hamcrest.version>3.0</hamcrest.version>
-
+        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 
 

--- a/storage-aws-s3/src/main/java/org/rutebanken/helper/aws/repository/S3BlobStoreRepository.java
+++ b/storage-aws-s3/src/main/java/org/rutebanken/helper/aws/repository/S3BlobStoreRepository.java
@@ -4,6 +4,8 @@ import org.rutebanken.helper.storage.BlobAlreadyExistsException;
 import org.rutebanken.helper.storage.BlobStoreException;
 import org.rutebanken.helper.storage.model.BlobDescriptor;
 import org.rutebanken.helper.storage.repository.BlobStoreRepository;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -49,10 +51,14 @@ public class S3BlobStoreRepository implements BlobStoreRepository {
 
     @Override
     public InputStream getBlob(String objectName) {
-        return s3Client.getObject(
-                GetObjectRequest.builder().bucket(containerName).key(objectName).build(),
-                ResponseTransformer.toInputStream()
-        );
+        try {
+            return s3Client.getObject(
+                    GetObjectRequest.builder().bucket(containerName).key(objectName).build(),
+                    ResponseTransformer.toInputStream()
+            );
+        } catch (NoSuchKeyException e) {
+            return null;
+        }
     }
 
     @Override

--- a/storage-gcp-gcs/src/main/java/org/rutebanken/helper/gcp/repository/GcsBlobStoreRepository.java
+++ b/storage-gcp-gcs/src/main/java/org/rutebanken/helper/gcp/repository/GcsBlobStoreRepository.java
@@ -55,6 +55,11 @@ public class GcsBlobStoreRepository implements BlobStoreRepository {
     }
 
     @Override
+    public boolean exist(String objectName) {
+        return BlobStoreHelper.existBlob(storage, containerName, objectName);
+    }
+
+    @Override
     public InputStream getBlob(String name) {
         return BlobStoreHelper.getBlob(storage, containerName, name);
     }

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -50,6 +50,11 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation-api.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/storage/src/main/java/org/rutebanken/helper/storage/repository/BlobStoreRepository.java
+++ b/storage/src/main/java/org/rutebanken/helper/storage/repository/BlobStoreRepository.java
@@ -16,6 +16,7 @@
 
 package org.rutebanken.helper.storage.repository;
 
+import jakarta.annotation.Nullable;
 import org.rutebanken.helper.storage.BlobAlreadyExistsException;
 import org.rutebanken.helper.storage.model.BlobDescriptor;
 
@@ -32,11 +33,21 @@ public interface BlobStoreRepository {
 
 
     /**
+     * Return true if the given blob exists in the repository.
+     * The default implementation retrieves the object and test for nullity.
+     * Specific implementations can provide an optimized algorithm.
+     */
+    default boolean exist(String objectName) {
+      return getBlob(objectName) != null;
+    }
+
+    /**
      * Download a blob from storage.
      *
      * @param objectName the name of the blob
-     * @return an InputStream on the file content.
+     * @return an InputStream on the file content or null if the object does not exist.
      */
+    @Nullable
     InputStream getBlob(String objectName);
 
     /**

--- a/storage/src/test/java/org/rutebanken/helper/storage/repository/InMemoryBlobStoreRepositoryTest.java
+++ b/storage/src/test/java/org/rutebanken/helper/storage/repository/InMemoryBlobStoreRepositoryTest.java
@@ -1,0 +1,26 @@
+package org.rutebanken.helper.storage.repository;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+class InMemoryBlobStoreRepositoryTest {
+
+    public static final String BLOB_NAME = "blobName";
+    public static final byte[] BLOB_CONTENT = "content".getBytes();
+
+    @Test
+    void testUploadExistAndGet() throws IOException {
+        InMemoryBlobStoreRepository repository = new InMemoryBlobStoreRepository(new HashMap<>());
+        repository.uploadBlob(BLOB_NAME, new ByteArrayInputStream(BLOB_CONTENT));
+        assertTrue(repository.exist(BLOB_NAME));
+        InputStream blob = repository.getBlob(BLOB_NAME);
+        assertNotNull(blob);
+        assertArrayEquals(BLOB_CONTENT, blob.readAllBytes());
+    }
+  
+}

--- a/storage/src/test/java/org/rutebanken/helper/storage/repository/LocalDiskBlobStoreRepositoryTest.java
+++ b/storage/src/test/java/org/rutebanken/helper/storage/repository/LocalDiskBlobStoreRepositoryTest.java
@@ -1,0 +1,31 @@
+package org.rutebanken.helper.storage.repository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocalDiskBlobStoreRepositoryTest {
+
+    public static final String BLOB_NAME = "blobName";
+    public static final byte[] BLOB_CONTENT = "content".getBytes();
+
+    @TempDir
+    File tempDirectory;
+
+    @Test
+    void testUploadExistAndGet() throws IOException {
+        LocalDiskBlobStoreRepository repository = new LocalDiskBlobStoreRepository(tempDirectory.getAbsolutePath());
+        repository.uploadBlob(BLOB_NAME, new ByteArrayInputStream(BLOB_CONTENT));
+        assertTrue(repository.exist(BLOB_NAME));
+        InputStream blob = repository.getBlob(BLOB_NAME);
+        assertNotNull(blob);
+        assertArrayEquals(BLOB_CONTENT, blob.readAllBytes());
+    }
+
+}


### PR DESCRIPTION
Add a method to check if a blob exists in the repository.
A default implementation is provided that retrieves the object and test for nullity.
This requires clarifying the behavior of the method `BlobStoreRepository.getBlob()` when the requested blob does not exist.
The S3 implementation is adapted to return `null` when the object does not exist, instead of throwing an exception.