### PR TITLE
Feature/spring boot 4

### DIFF
--- a/calendar-helper/pom.xml
+++ b/calendar-helper/pom.xml
@@ -22,7 +22,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/entur-google-pubsub/pom.xml
+++ b/entur-google-pubsub/pom.xml
@@ -23,7 +23,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>entur-google-pubsub</artifactId>

--- a/hazelcast4-helper/pom.xml
+++ b/hazelcast4-helper/pom.xml
@@ -22,7 +22,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>helper</artifactId>
         <groupId>org.entur.ror.helpers</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -44,7 +44,10 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-security-oauth2-client</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/oauth2/src/main/java/org/entur/oauth2/AuthorizedClientServiceReactiveOAuth2AuthorizedClientManagerBuilder.java
+++ b/oauth2/src/main/java/org/entur/oauth2/AuthorizedClientServiceReactiveOAuth2AuthorizedClientManagerBuilder.java
@@ -2,8 +2,8 @@ package org.entur.oauth2;
 
 import java.util.List;
 import java.util.Map;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesMapper;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientPropertiesMapper;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.ClientCredentialsReactiveOAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.InMemoryReactiveOAuth2AuthorizedClientService;

--- a/oauth2/src/main/java/org/entur/oauth2/AuthorizedWebClientBuilder.java
+++ b/oauth2/src/main/java/org/entur/oauth2/AuthorizedWebClientBuilder.java
@@ -2,8 +2,8 @@ package org.entur.oauth2;
 
 import java.util.List;
 import java.util.Map;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesMapper;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientPropertiesMapper;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.ClientCredentialsReactiveOAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.InMemoryReactiveOAuth2AuthorizedClientService;

--- a/oauth2/src/main/java/org/entur/oauth2/JwtRoleAssignmentExtractor.java
+++ b/oauth2/src/main/java/org/entur/oauth2/JwtRoleAssignmentExtractor.java
@@ -1,6 +1,5 @@
 package org.entur.oauth2;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.rutebanken.helper.organisation.RoleAssignment;

--- a/oauth2/src/main/java/org/entur/oauth2/JwtRoleAssignmentExtractor.java
+++ b/oauth2/src/main/java/org/entur/oauth2/JwtRoleAssignmentExtractor.java
@@ -1,6 +1,5 @@
 package org.entur.oauth2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +9,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Extract {@link RoleAssignment}s from {@link JwtAuthenticationToken}.
@@ -118,7 +119,7 @@ public class JwtRoleAssignmentExtractor implements RoleAssignmentExtractor {
     }
     try {
       return MAPPER.readValue((String) roleAssignment, RoleAssignment.class);
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       throw new IllegalArgumentException(
         "Exception while parsing role assignments from JSON",
         e

--- a/oauth2/src/main/java/org/entur/oauth2/OAuth2TokenService.java
+++ b/oauth2/src/main/java/org/entur/oauth2/OAuth2TokenService.java
@@ -16,7 +16,7 @@
 
 package org.entur.oauth2;
 
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;

--- a/organisation/README.md
+++ b/organisation/README.md
@@ -23,7 +23,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.entur.ror.helpers</groupId>
     <artifactId>organisation</artifactId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/organisation/pom.xml
+++ b/organisation/pom.xml
@@ -22,7 +22,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/permission-store-proxy/pom.xml
+++ b/permission-store-proxy/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>organisation</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/permission-store-proxy/pom.xml
+++ b/permission-store-proxy/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -38,13 +38,13 @@
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>organisation</artifactId>
-            <version>6.2.0-SNAPSHOT</version>
+            <version>7.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>oauth2</artifactId>
-            <version>6.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>4.10.0</version>
+        <version>6.1.0</version>
     </parent>
 
     <groupId>org.entur.ror.helpers</groupId>
     <artifactId>helper</artifactId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>entur-helper</name>
@@ -98,7 +98,10 @@
         <prettier-java.version>2.1.0</prettier-java.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
         <plugin.prettier.goal>write</plugin.prettier.goal>
-
+        <testcontainers-junit-jupiter.version>1.20.6</testcontainers-junit-jupiter.version>
+        <testcontainers-gcloud.version>1.20.6</testcontainers-gcloud.version>
+        <testcontainers-localstack.version>1.20.6</testcontainers-localstack.version>
+        <sping-boot-loader-tools.version>4.0.4</sping-boot-loader-tools.version>
 
         <!-- empty argLine property, the value is set up by Jacoco during unit tests execution -->
         <argLine/>
@@ -152,6 +155,30 @@
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${testcontainers-junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>localstack</artifactId>
+                <version>${testcontainers-localstack.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>gcloud</artifactId>
+                <version>${testcontainers-gcloud.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-loader-tools</artifactId>
+                <version>${sping-boot-loader-tools.version}</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-loader-tools</artifactId>
-                <version>${sping-boot-loader-tools.version}</version>
+                <version>${spring-boot-loader-tools.version}</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <testcontainers-junit-jupiter.version>1.20.6</testcontainers-junit-jupiter.version>
         <testcontainers-gcloud.version>1.20.6</testcontainers-gcloud.version>
         <testcontainers-localstack.version>1.20.6</testcontainers-localstack.version>
-        <sping-boot-loader-tools.version>4.0.4</sping-boot-loader-tools.version>
+        <spring-boot-loader-tools.version>4.0.4</spring-boot-loader-tools.version>
 
         <!-- empty argLine property, the value is set up by Jacoco during unit tests execution -->
         <argLine/>

--- a/slack/pom.xml
+++ b/slack/pom.xml
@@ -22,7 +22,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/slack/pom.xml
+++ b/slack/pom.xml
@@ -47,7 +47,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
+++ b/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
@@ -1,6 +1,5 @@
 package org.rutebanken.helper.slack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -11,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class SlackPostService {

--- a/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
+++ b/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
@@ -15,44 +15,51 @@ import tools.jackson.databind.ObjectMapper;
 @Service
 public class SlackPostService {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(SlackPostService.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+    SlackPostService.class
+  );
 
-	private final String slackEndpoint;
-	private final ObjectMapper objectMapper;
+  private final String slackEndpoint;
+  private final ObjectMapper objectMapper;
 
-	@Autowired
-	public SlackPostService(@Value("${helper.slack.endpoint}") String slackEndpoint) {
-		this.slackEndpoint = slackEndpoint;
-		objectMapper = new ObjectMapper();
-	}
+  @Autowired
+  public SlackPostService(
+    @Value("${helper.slack.endpoint}") String slackEndpoint
+  ) {
+    this.slackEndpoint = slackEndpoint;
+    objectMapper = new ObjectMapper();
+  }
 
-	public boolean publish(String messageText) {
-		SlackPayload payload = new SlackPayload(messageText);
-		return publish(payload);
-	}
+  public boolean publish(String messageText) {
+    SlackPayload payload = new SlackPayload(messageText);
+    return publish(payload);
+  }
 
-	public boolean publish(SlackPayload payload) {
-		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-			String json = objectMapper.writeValueAsString(payload);
-			LOGGER.debug("Will try to send the following to slack: {}", json);
-			HttpPost httpPost = new HttpPost(slackEndpoint);
-			httpPost.setEntity(new StringEntity(json));
-			httpPost.addHeader("Content-Type", "application/json");
-			httpclient.execute(
-				httpPost,
-				response -> {
-					if (LOGGER.isInfoEnabled()) {
-						LOGGER.info("Entity as response from hubot: {}", EntityUtils.toString(response.getEntity()));
-					}
-					return null;
-				}
-			);
-			return true;
-		} catch (Exception e) {
-			LOGGER.error("Could not publish message", e);
-			return false;
-		}
-	}
+  public boolean publish(SlackPayload payload) {
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      String json = objectMapper.writeValueAsString(payload);
+      LOGGER.debug("Will try to send the following to slack: {}", json);
+      HttpPost httpPost = new HttpPost(slackEndpoint);
+      httpPost.setEntity(new StringEntity(json));
+      httpPost.addHeader("Content-Type", "application/json");
+      httpclient.execute(
+        httpPost,
+        response -> {
+          if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(
+              "Entity as response from hubot: {}",
+              EntityUtils.toString(response.getEntity())
+            );
+          }
+          return null;
+        }
+      );
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Could not publish message", e);
+      return false;
+    }
+  }
 
-	public record SlackPayload(String text) {}
+  public record SlackPayload(String text) {}
 }

--- a/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
+++ b/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
@@ -15,51 +15,48 @@ import org.springframework.stereotype.Service;
 @Service
 public class SlackPostService {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(
-    SlackPostService.class
-  );
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            SlackPostService.class);
 
-  private final String slackEndpoint;
-  private final ObjectMapper objectMapper;
+    private final String slackEndpoint;
+    private final ObjectMapper objectMapper;
 
-  @Autowired
-  public SlackPostService(
-    @Value("${helper.slack.endpoint}") String slackEndpoint
-  ) {
-    this.slackEndpoint = slackEndpoint;
-    objectMapper = new ObjectMapper();
-  }
-
-  public boolean publish(String messageText) {
-    SlackPayload payload = new SlackPayload(messageText);
-    return publish(payload);
-  }
-
-  public boolean publish(SlackPayload payload) {
-    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-      String json = objectMapper.writeValueAsString(payload);
-      LOGGER.debug("Will try to send the following to slack: {}", json);
-      HttpPost httpPost = new HttpPost(slackEndpoint);
-      httpPost.setEntity(new StringEntity(json));
-      httpPost.addHeader("Content-Type", "application/json");
-      httpclient.execute(
-        httpPost,
-        response -> {
-          if (LOGGER.isInfoEnabled()) {
-            LOGGER.info(
-              "Entity as response from hubot: {}",
-              EntityUtils.toString(response.getEntity())
-            );
-          }
-          return null;
-        }
-      );
-      return true;
-    } catch (Exception e) {
-      LOGGER.error("Could not publish message", e);
-      return false;
+    @Autowired
+    public SlackPostService(
+            @Value("${helper.slack.endpoint}") String slackEndpoint) {
+        this.slackEndpoint = slackEndpoint;
+        objectMapper = new ObjectMapper();
     }
-  }
 
-  public record SlackPayload(String text) {}
+    public boolean publish(String messageText) {
+        SlackPayload payload = new SlackPayload(messageText);
+        return publish(payload);
+    }
+
+    public boolean publish(SlackPayload payload) {
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            String json = objectMapper.writeValueAsString(payload);
+            LOGGER.debug("Will try to send the following to slack: {}", json);
+            HttpPost httpPost = new HttpPost(slackEndpoint);
+            httpPost.setEntity(new StringEntity(json));
+            httpPost.addHeader("Content-Type", "application/json");
+            httpclient.execute(
+                    httpPost,
+                    response -> {
+                        if (LOGGER.isInfoEnabled()) {
+                            LOGGER.info(
+                                    "Entity as response from hubot: {}",
+                                    EntityUtils.toString(response.getEntity()));
+                        }
+                        return null;
+                    });
+            return true;
+        } catch (Exception e) {
+            LOGGER.error("Could not publish message", e);
+            return false;
+        }
+    }
+
+    public record SlackPayload(String text) {
+    }
 }

--- a/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
+++ b/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
@@ -1,6 +1,6 @@
 package org.rutebanken.helper.slack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;

--- a/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
+++ b/slack/src/main/java/org/rutebanken/helper/slack/SlackPostService.java
@@ -1,6 +1,5 @@
 package org.rutebanken.helper.slack;
 
-import tools.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -11,52 +10,49 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class SlackPostService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(
-            SlackPostService.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SlackPostService.class);
 
-    private final String slackEndpoint;
-    private final ObjectMapper objectMapper;
+	private final String slackEndpoint;
+	private final ObjectMapper objectMapper;
 
-    @Autowired
-    public SlackPostService(
-            @Value("${helper.slack.endpoint}") String slackEndpoint) {
-        this.slackEndpoint = slackEndpoint;
-        objectMapper = new ObjectMapper();
-    }
+	@Autowired
+	public SlackPostService(@Value("${helper.slack.endpoint}") String slackEndpoint) {
+		this.slackEndpoint = slackEndpoint;
+		objectMapper = new ObjectMapper();
+	}
 
-    public boolean publish(String messageText) {
-        SlackPayload payload = new SlackPayload(messageText);
-        return publish(payload);
-    }
+	public boolean publish(String messageText) {
+		SlackPayload payload = new SlackPayload(messageText);
+		return publish(payload);
+	}
 
-    public boolean publish(SlackPayload payload) {
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            String json = objectMapper.writeValueAsString(payload);
-            LOGGER.debug("Will try to send the following to slack: {}", json);
-            HttpPost httpPost = new HttpPost(slackEndpoint);
-            httpPost.setEntity(new StringEntity(json));
-            httpPost.addHeader("Content-Type", "application/json");
-            httpclient.execute(
-                    httpPost,
-                    response -> {
-                        if (LOGGER.isInfoEnabled()) {
-                            LOGGER.info(
-                                    "Entity as response from hubot: {}",
-                                    EntityUtils.toString(response.getEntity()));
-                        }
-                        return null;
-                    });
-            return true;
-        } catch (Exception e) {
-            LOGGER.error("Could not publish message", e);
-            return false;
-        }
-    }
+	public boolean publish(SlackPayload payload) {
+		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+			String json = objectMapper.writeValueAsString(payload);
+			LOGGER.debug("Will try to send the following to slack: {}", json);
+			HttpPost httpPost = new HttpPost(slackEndpoint);
+			httpPost.setEntity(new StringEntity(json));
+			httpPost.addHeader("Content-Type", "application/json");
+			httpclient.execute(
+				httpPost,
+				response -> {
+					if (LOGGER.isInfoEnabled()) {
+						LOGGER.info("Entity as response from hubot: {}", EntityUtils.toString(response.getEntity()));
+					}
+					return null;
+				}
+			);
+			return true;
+		} catch (Exception e) {
+			LOGGER.error("Could not publish message", e);
+			return false;
+		}
+	}
 
-    public record SlackPayload(String text) {
-    }
+	public record SlackPayload(String text) {}
 }

--- a/stopplace-changelog-starter/pom.xml
+++ b/stopplace-changelog-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>stopplace-changelog</artifactId>
-            <version>6.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -44,5 +44,32 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/stopplace-changelog-starter/src/test/java/org/entur/ror/helpers/stopplace/changelog/config/StopPlaceChangelogIntegrationTest.java
+++ b/stopplace-changelog-starter/src/test/java/org/entur/ror/helpers/stopplace/changelog/config/StopPlaceChangelogIntegrationTest.java
@@ -2,7 +2,6 @@ package org.entur.ror.helpers.stopplace.changelog.config;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -29,13 +28,13 @@ import org.rutebanken.irkalla.avro.EnumType;
 import org.rutebanken.irkalla.avro.StopPlaceChangelogEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * Integration test for the StopPlace Changelog starter configuration.
@@ -43,15 +42,7 @@ import org.springframework.test.context.TestPropertySource;
  * all the necessary beans and that the Kafka listener works correctly.
  */
 @SpringBootTest(classes = TestApplication.class)
-@EmbeddedKafka(
-  partitions = 3,
-  topics = "test-stop-place-changelog",
-  brokerProperties = {
-    "listeners=PLAINTEXT://localhost:0",
-    "port=0",
-    "auto.create.topics.enable=true",
-  }
-)
+@EmbeddedKafka(partitions = 3, topics = "test-stop-place-changelog")
 @TestPropertySource(
   properties = {
     "org.rutebanken.helper.stopplace.changelog.enabled=true",
@@ -71,7 +62,7 @@ class StopPlaceChangelogIntegrationTest {
   @Autowired
   private ChangelogConsumerController changelogConsumerController;
 
-  @MockBean
+  @MockitoBean
   private StopPlaceRepository stopPlaceRepository;
 
   @Autowired

--- a/stopplace-changelog/pom.xml
+++ b/stopplace-changelog/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -89,6 +89,24 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/storage-aws-s3/pom.xml
+++ b/storage-aws-s3/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>storage</artifactId>
-            <version>6.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!--
         # AWS API clients
@@ -84,6 +84,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>localstack</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/storage-aws-s3/src/main/java/org/rutebanken/helper/aws/repository/S3BlobStoreRepository.java
+++ b/storage-aws-s3/src/main/java/org/rutebanken/helper/aws/repository/S3BlobStoreRepository.java
@@ -15,8 +15,6 @@ import org.rutebanken.helper.storage.BlobAlreadyExistsException;
 import org.rutebanken.helper.storage.BlobStoreException;
 import org.rutebanken.helper.storage.model.BlobDescriptor;
 import org.rutebanken.helper.storage.repository.BlobStoreRepository;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;

--- a/storage-aws-s3/src/test/java/org/rutebanken/helper/aws/repository/S3BlobStoreRepositoryTests.java
+++ b/storage-aws-s3/src/test/java/org/rutebanken/helper/aws/repository/S3BlobStoreRepositoryTests.java
@@ -1,5 +1,7 @@
 package org.rutebanken.helper.aws.repository;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -9,10 +11,9 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.rutebanken.helper.storage.BlobAlreadyExistsException;
 import org.rutebanken.helper.storage.model.BlobDescriptor;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -50,7 +51,7 @@ public class S3BlobStoreRepositoryTests {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     localStack =
       new LocalStackContainer(
@@ -61,7 +62,7 @@ public class S3BlobStoreRepositoryTests {
     localStack.start();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     s3Client =
       S3Client
@@ -91,14 +92,14 @@ public class S3BlobStoreRepositoryTests {
       new ByteArrayInputStream(original.getBytes())
     );
     assertBlobExists(TEST_BUCKET, "myblob", true);
-    Assert.assertEquals(
+    assertEquals(
       original,
       new String(blobStore.getBlob("myblob").readAllBytes())
     );
-    Assert.assertTrue(blobStore.delete("myblob"));
+    assertTrue(blobStore.delete("myblob"));
   }
 
-  @Test(expected = BlobAlreadyExistsException.class)
+  @Test
   public void cannotOverWriteExistingObject() {
     String original = "another bytes the dust";
     assertBlobExists(TEST_BUCKET, "anotherblob", false);
@@ -107,9 +108,14 @@ public class S3BlobStoreRepositoryTests {
       new ByteArrayInputStream(original.getBytes())
     );
     assertBlobExists(TEST_BUCKET, "anotherblob", true);
-    blobStore.uploadNewBlob(
-      "anotherblob",
-      new ByteArrayInputStream("something silly".getBytes())
+    assertThrows(
+      BlobAlreadyExistsException.class,
+      () -> {
+        blobStore.uploadNewBlob(
+          "anotherblob",
+          new ByteArrayInputStream("something silly".getBytes())
+        );
+      }
     );
   }
 
@@ -129,7 +135,7 @@ public class S3BlobStoreRepositoryTests {
     HeadObjectResponse response = s3Client.headObject(request ->
       request.bucket(TEST_BUCKET).key("json")
     );
-    Assert.assertEquals(contentType, response.contentType());
+    assertEquals(contentType, response.contentType());
   }
 
   @Test
@@ -140,7 +146,7 @@ public class S3BlobStoreRepositoryTests {
     blobStore.uploadBlob("smallfile", asStream(content));
     blobStore.copyBlob(TEST_BUCKET, "smallfile", targetBucket, "tinyfile");
     blobStore.setContainerName(targetBucket);
-    Assert.assertEquals(
+    assertEquals(
       content,
       new String(blobStore.getBlob("tinyfile").readAllBytes())
     );
@@ -166,7 +172,7 @@ public class S3BlobStoreRepositoryTests {
       "barelyworthmentioningfile"
     );
     blobStore.setContainerName(targetBucket);
-    Assert.assertEquals(
+    assertEquals(
       content,
       new String(blobStore.getBlob("barelyworthmentioningfile").readAllBytes())
     );
@@ -221,17 +227,13 @@ public class S3BlobStoreRepositoryTests {
       response =
         s3Client.headObject(request -> request.bucket(bucket).key(key));
     } catch (NoSuchKeyException ignored) {}
-    if (!exists && response != null) {
-      Assert.fail(bucket + " / " + key + " exists");
-    }
-    if (exists && response == null) {
-      Assert.fail(bucket + " / " + key + " does not exist");
-    }
+    assertFalse(!exists && response != null, bucket + " / " + key + " exists");
+    assertFalse(
+      exists && response == null,
+      bucket + " / " + key + " does not exist"
+    );
     if (expectedMetadata != null) {
-      Assert.assertEquals(
-        expectedMetadata,
-        mimeDecodeValues(response.metadata())
-      );
+      assertEquals(expectedMetadata, mimeDecodeValues(response.metadata()));
     }
   }
 

--- a/storage-gcp-gcs/pom.xml
+++ b/storage-gcp-gcs/pom.xml
@@ -22,7 +22,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -44,7 +44,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>storage</artifactId>
-            <version>6.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
 

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -22,7 +22,7 @@ Inspired by: https://github.com/fabric8io/ipaas-quickstarts/
     <parent>
         <groupId>org.entur.ror.helpers</groupId>
         <artifactId>helper</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
Upgrade to Spring Boot 4

This version upgrades to ror-superpom 6.1.0 that includes Spring Boot 4.0.4

The changes done here are due to differences in Spring Boot 4 and the versions of dependencies that it brings along, like Kafka, Jackson and JUnit5.

All unit tests pass locally and build works locally