### PR TITLE
Harmonize Renovate onto shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "baseBranches": [
-    "master"
-  ],
-  "packageRules": [
-    {
-      "matchPackageNames": [
-        "org.entur.ror:superpom"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true
-    }
+    "github>entur/ror-renovate-config"
   ]
 }


### PR DESCRIPTION
## Harmonize onto the shared Renovate config

Replaces the bare `config:recommended` preset with the team's shared preset
`github>entur/ror-renovate-config`.

Dropped local rules the shared config already covers:
- `org.entur.ror:superpom` minor/patch automerge — the shared config already
  automerges `^org.entur` / `^org.rutebanken` packages on minor/patch.
- `baseBranches: [master]` — `master` is the default branch, so no override needed.



---
_Part of the team-wide Renovate harmonization. Depends on the shared-config update **entur/ror-renovate-config#12** (merge that first)._