### PR TITLE
Fix JWKS "Read timed out" errors on JWT auth under Spring Security 7

### DIFF
--- a/oauth2/src/main/java/org/entur/oauth2/multiissuer/MultiIssuerAuthenticationManagerResolver.java
+++ b/oauth2/src/main/java/org/entur/oauth2/multiissuer/MultiIssuerAuthenticationManagerResolver.java
@@ -2,6 +2,7 @@ package org.entur.oauth2.multiissuer;
 
 import com.nimbusds.jwt.JWTParser;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -9,19 +10,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.entur.oauth2.AudienceValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Resolve the @{@link AuthenticationManager} that should authenticate the current JWT token.
@@ -33,6 +36,23 @@ import org.springframework.util.StringUtils;
 public class MultiIssuerAuthenticationManagerResolver
   implements AuthenticationManagerResolver<HttpServletRequest> {
 
+  /**
+   * Default connect timeout for the JWKS/OIDC-discovery HTTP client. Chosen to be generous enough
+   * for a cold TLS handshake to Auth0 over the public internet, but still bounded so a genuine
+   * outage fails fast instead of tying up worker threads. Deliberately larger than Spring
+   * Security 7's 500 ms default, which was too short for that handshake.
+   */
+  public static final Duration DEFAULT_JWKS_CONNECT_TIMEOUT =
+    Duration.ofSeconds(3);
+
+  /**
+   * Default read timeout for the JWKS/OIDC-discovery HTTP client. See
+   * {@link #DEFAULT_JWKS_CONNECT_TIMEOUT} for the rationale.
+   */
+  public static final Duration DEFAULT_JWKS_READ_TIMEOUT = Duration.ofSeconds(
+    5
+  );
+
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final String enturInternalAuth0Audience;
@@ -41,6 +61,8 @@ public class MultiIssuerAuthenticationManagerResolver
   private final String enturPartnerAuth0Audience;
   private final List<String> enturPartnerAuth0Audiences;
   private final String enturPartnerAuth0Issuer;
+  private final Duration jwksConnectTimeout;
+  private final Duration jwksReadTimeout;
 
   private final BearerTokenResolver resolver = new DefaultBearerTokenResolver();
   private final Map<String, AuthenticationManager> authenticationManagers =
@@ -72,12 +94,36 @@ public class MultiIssuerAuthenticationManagerResolver
     List<String> enturPartnerAuth0Audiences,
     String enturPartnerAuth0Issuer
   ) {
+    this(
+      enturInternalAuth0Audience,
+      enturInternalAuth0Audiences,
+      enturInternalAuth0Issuer,
+      enturPartnerAuth0Audience,
+      enturPartnerAuth0Audiences,
+      enturPartnerAuth0Issuer,
+      DEFAULT_JWKS_CONNECT_TIMEOUT,
+      DEFAULT_JWKS_READ_TIMEOUT
+    );
+  }
+
+  protected MultiIssuerAuthenticationManagerResolver(
+    String enturInternalAuth0Audience,
+    List<String> enturInternalAuth0Audiences,
+    String enturInternalAuth0Issuer,
+    String enturPartnerAuth0Audience,
+    List<String> enturPartnerAuth0Audiences,
+    String enturPartnerAuth0Issuer,
+    Duration jwksConnectTimeout,
+    Duration jwksReadTimeout
+  ) {
     this.enturInternalAuth0Audience = enturInternalAuth0Audience;
     this.enturInternalAuth0Audiences = enturInternalAuth0Audiences;
     this.enturInternalAuth0Issuer = enturInternalAuth0Issuer;
     this.enturPartnerAuth0Audience = enturPartnerAuth0Audience;
     this.enturPartnerAuth0Audiences = enturPartnerAuth0Audiences;
     this.enturPartnerAuth0Issuer = enturPartnerAuth0Issuer;
+    this.jwksConnectTimeout = jwksConnectTimeout;
+    this.jwksReadTimeout = jwksReadTimeout;
   }
 
   /**
@@ -100,9 +146,10 @@ public class MultiIssuerAuthenticationManagerResolver
       );
     }
 
-    NimbusJwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(
-      enturInternalAuth0Issuer
-    );
+    NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder
+      .withIssuerLocation(enturInternalAuth0Issuer)
+      .restOperations(jwksRestOperations())
+      .build();
 
     OAuth2TokenValidator<Jwt> withIssuer =
       JwtValidators.createDefaultWithIssuer(enturInternalAuth0Issuer);
@@ -133,9 +180,10 @@ public class MultiIssuerAuthenticationManagerResolver
       );
     }
 
-    NimbusJwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(
-      enturPartnerAuth0Issuer
-    );
+    NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder
+      .withIssuerLocation(enturPartnerAuth0Issuer)
+      .restOperations(jwksRestOperations())
+      .build();
 
     OAuth2TokenValidator<Jwt> withIssuer =
       JwtValidators.createDefaultWithIssuer(enturPartnerAuth0Issuer);
@@ -144,6 +192,20 @@ public class MultiIssuerAuthenticationManagerResolver
     jwtDecoder.setJwtValidator(withAudience);
 
     return jwtDecoder;
+  }
+
+  /**
+   * Build the {@link RestOperations} used by the {@link NimbusJwtDecoder}s for OIDC discovery and
+   * ongoing JWKS key-set fetches. Configured with explicit connect/read timeouts so it does not
+   * inherit Spring Security 7's 500 ms default, which is too short for a cold TLS handshake to
+   * Auth0.
+   */
+  RestOperations jwksRestOperations() {
+    SimpleClientHttpRequestFactory requestFactory =
+      new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(jwksConnectTimeout);
+    requestFactory.setReadTimeout(jwksReadTimeout);
+    return new RestTemplate(requestFactory);
   }
 
   private JwtDecoder jwtDecoder(String issuer) {

--- a/oauth2/src/main/java/org/entur/oauth2/multiissuer/MultiIssuerAuthenticationManagerResolverBuilder.java
+++ b/oauth2/src/main/java/org/entur/oauth2/multiissuer/MultiIssuerAuthenticationManagerResolverBuilder.java
@@ -1,5 +1,6 @@
 package org.entur.oauth2.multiissuer;
 
+import java.time.Duration;
 import java.util.List;
 
 public class MultiIssuerAuthenticationManagerResolverBuilder {
@@ -10,6 +11,10 @@ public class MultiIssuerAuthenticationManagerResolverBuilder {
   private String enturPartnerAuth0Audience;
   private List<String> enturPartnerAuth0Audiences;
   private String enturPartnerAuth0Issuer;
+  private Duration jwksConnectTimeout =
+    MultiIssuerAuthenticationManagerResolver.DEFAULT_JWKS_CONNECT_TIMEOUT;
+  private Duration jwksReadTimeout =
+    MultiIssuerAuthenticationManagerResolver.DEFAULT_JWKS_READ_TIMEOUT;
 
   public MultiIssuerAuthenticationManagerResolverBuilder withEnturInternalAuth0Audience(
     String enturInternalAuth0Audience
@@ -57,6 +62,28 @@ public class MultiIssuerAuthenticationManagerResolverBuilder {
     return this;
   }
 
+  /**
+   * Override the connect timeout for the JWKS/OIDC-discovery HTTP client. Defaults to
+   * {@link MultiIssuerAuthenticationManagerResolver#DEFAULT_JWKS_CONNECT_TIMEOUT}.
+   */
+  public MultiIssuerAuthenticationManagerResolverBuilder withJwksConnectTimeout(
+    Duration jwksConnectTimeout
+  ) {
+    this.jwksConnectTimeout = jwksConnectTimeout;
+    return this;
+  }
+
+  /**
+   * Override the read timeout for the JWKS/OIDC-discovery HTTP client. Defaults to
+   * {@link MultiIssuerAuthenticationManagerResolver#DEFAULT_JWKS_READ_TIMEOUT}.
+   */
+  public MultiIssuerAuthenticationManagerResolverBuilder withJwksReadTimeout(
+    Duration jwksReadTimeout
+  ) {
+    this.jwksReadTimeout = jwksReadTimeout;
+    return this;
+  }
+
   public MultiIssuerAuthenticationManagerResolver build() {
     return new MultiIssuerAuthenticationManagerResolver(
       enturInternalAuth0Audience,
@@ -64,7 +91,9 @@ public class MultiIssuerAuthenticationManagerResolverBuilder {
       enturInternalAuth0Issuer,
       enturPartnerAuth0Audience,
       enturPartnerAuth0Audiences,
-      enturPartnerAuth0Issuer
+      enturPartnerAuth0Issuer,
+      jwksConnectTimeout,
+      jwksReadTimeout
     );
   }
 }

--- a/oauth2/src/test/java/org/entur/oauth2/multiissuer/MultiIssuerJwksTimeoutTest.java
+++ b/oauth2/src/test/java/org/entur/oauth2/multiissuer/MultiIssuerJwksTimeoutTest.java
@@ -1,0 +1,93 @@
+package org.entur.oauth2.multiissuer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestOperations;
+
+/**
+ * Tests for the JWKS {@link RestOperations} timeouts configured by
+ * {@link MultiIssuerAuthenticationManagerResolver}.
+ *
+ * <p>Background: Spring Security 7 changed the default JWKS HTTP client timeout from infinite to
+ * 500 ms. A cold TLS handshake from a GKE pod to Auth0 regularly exceeds 500 ms, so key-cache
+ * refreshes started throwing {@code SocketTimeoutException: Read timed out}. The resolver now
+ * builds its decoders with an explicit {@code RestOperations} carrying generous, configurable
+ * timeouts. These tests exercise that {@code RestOperations} directly against a slow local HTTP
+ * server.
+ */
+class MultiIssuerJwksTimeoutTest {
+
+  private HttpServer server;
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  private String startServerWithDelay(Duration delay) throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+      "/",
+      exchange -> {
+        try {
+          Thread.sleep(delay.toMillis());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "text/plain");
+        exchange.sendResponseHeaders(200, body.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+          os.write(body);
+        }
+      }
+    );
+    server.start();
+    return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+  }
+
+  @Test
+  void defaultReadTimeoutAllowsJwksResponseSlowerThanSpringSecurityDefault()
+    throws Exception {
+    // Spring Security 7's default JWKS read timeout is 500 ms. Simulate a JWKS response that takes
+    // ~700 ms (a plausible cold TLS handshake to Auth0) and confirm the default 5 s read timeout
+    // configured here does not abort it.
+    String url = startServerWithDelay(Duration.ofMillis(700));
+    RestOperations restOperations =
+      new MultiIssuerAuthenticationManagerResolverBuilder()
+        .build()
+        .jwksRestOperations();
+
+    String body = restOperations.getForObject(url, String.class);
+
+    assertEquals("{}", body);
+  }
+
+  @Test
+  void configuredReadTimeoutIsEnforced() throws Exception {
+    // A caller may tighten the read timeout so a genuinely slow JWKS endpoint fails fast rather
+    // than tying up worker threads. Confirm the configured value is actually applied.
+    String url = startServerWithDelay(Duration.ofMillis(700));
+    RestOperations restOperations =
+      new MultiIssuerAuthenticationManagerResolverBuilder()
+        .withJwksReadTimeout(Duration.ofMillis(200))
+        .build()
+        .jwksRestOperations();
+
+    assertThrows(
+      ResourceAccessException.class,
+      () -> restOperations.getForObject(url, String.class)
+    );
+  }
+}


### PR DESCRIPTION
Spring Security 7 changed the default JWKS HTTP client timeout from infinite to 500 ms. That is too short for a cold TLS handshake to Auth0, so intermittent key-cache refreshes now fail with SocketTimeoutException and reject the request.

Fix: build the NimbusJwtDecoders with an explicit RestOperations carrying sane, configurable timeouts (default connect 3s / read 5s) instead of relying on the 500 ms default. Applies to both the internal and partner Auth0 decoders in MultiIssuerAuthenticationManagerResolver; timeouts are tunable via the builder.